### PR TITLE
Set default opts for `CheckpointerInternal`

### DIFF
--- a/packages/node_modules/pouchdb-checkpointer/src/index.js
+++ b/packages/node_modules/pouchdb-checkpointer/src/index.js
@@ -73,12 +73,15 @@ function updateCheckpoint(db, id, checkpoint, session, returnValue) {
 }
 
 class CheckpointerInternal {
-  constructor(src, target, id, returnValue, opts) {
+  constructor(src, target, id, returnValue, opts = {
+    writeSourceCheckpoint: true,
+    writeTargetCheckpoint: true,
+  }) {
     this.src = src;
     this.target = target;
     this.id = id;
     this.returnValue = returnValue;
-    this.opts = opts || {};
+    this.opts = opts;
   }
 
   writeCheckpoint(checkpoint, session) {


### PR DESCRIPTION
This patch fixes defaults for opts parameter of `CheckpointerInternal`.

Since `Checkpoint` is the backbone for replication, I've derived the "default" from it's `checkpoint` parameter:
If no `opts` parameter is passed, checkpoints for source and target checkpoints will be written.