### PR TITLE
fix: input isn't defined in array case

### DIFF
--- a/packages/node_modules/pouchdb-find/src/validateSelector.js
+++ b/packages/node_modules/pouchdb-find/src/validateSelector.js
@@ -99,7 +99,7 @@ var equalityOperators = [ '$eq', '$gt', '$gte', '$lt', '$lte' ];
 function validateSelector(input, isHttp) {
   if (Array.isArray(input)) {
     for (var entry of input) {
-      if (typeof entry === 'object' && value !== null) {
+      if (typeof entry === 'object' && entry !== null) {
         validateSelector(entry, isHttp);
       }
     }


### PR DESCRIPTION
Fixed comparison against an undeclared/undefined variable (`value !== null` always evaluates to `undefined !== null` when `input` is an array)

To me it looks like a copy & past mistake (102 looks similar to line 124)